### PR TITLE
Fix git checkout submodules action failure.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,10 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.0.0
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Formatting
       uses: github/super-linter@v4
       env:
@@ -38,10 +39,10 @@ jobs:
       - linting
       - formatting
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v1
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.0.0
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: Test workflow
       uses: snakemake/snakemake-github-action@v1.22.0
       with:


### PR DESCRIPTION
- This fixes the submodule checkout not working.
- The previous GitHub workflow action is no longer maintained and fails to build at all., see [here](https://github.com/textbook/git-checkout-submodule-action).